### PR TITLE
Add support to set PickerPage navigation button in Android

### DIFF
--- a/demo-angular/src/app/examples/styling/styling-example.component.html
+++ b/demo-angular/src/app/examples/styling/styling-example.component.html
@@ -4,7 +4,7 @@
 <GridLayout rows="50, *">
     <PickerField row="0" col="0" hint="This is hint" padding="10" class="picker-field" textField="name" id="picker"
         [items]="pickerItems" [pickerTitle]="pickerTitle" iOSCloseButtonIcon="14" iOSCloseButtonPosition="left"
-        androidCloseButtonPosition="actionBar" androidCloseButtonIcon="ic_media_previous">
+        androidCloseButtonPosition="navigationButton" androidCloseButtonIcon="ic_menu_back">
         <ng-template let-item="item">
             <GridLayout columns="auto, *" rows="auto, *">
                 <Label text="Static text: " colSpan="2" class="item-template-top-label"></Label>

--- a/demo-vue/app/components/Styling.vue
+++ b/demo-vue/app/components/Styling.vue
@@ -13,8 +13,8 @@
                   textField="name"
                   iOSCloseButtonIcon="14"
                   iOSCloseButtonPosition="left"
-                  androidCloseButtonPosition="actionBar"
-                  androidCloseButtonIcon="ic_media_previous">
+                  androidCloseButtonPosition="navigationButton"
+                  androidCloseButtonIcon="ic_menu_back">
         <v-template>
           <GridLayout columns="auto, *" rows="auto, *">
             <Label text="Static text: " colSpan="2" class="item-template-top-label"></Label>

--- a/demo/app/examples/styling/styling-page.xml
+++ b/demo/app/examples/styling/styling-page.xml
@@ -8,8 +8,8 @@
 								pickerTitle="{{ pickerTitle }}"
 								iOSCloseButtonIcon="14"
 								iOSCloseButtonPosition="left"
-								androidCloseButtonPosition="actionBar"
-								androidCloseButtonIcon="ic_media_previous">
+								androidCloseButtonPosition="navigationButton"
+								androidCloseButtonIcon="ic_menu_back">
 			<picker:PickerField.itemTemplate>
 				<GridLayout columns="auto, *" rows="auto, *">
 					<Label text="Static text: " colSpan="2" class="item-template-top-label"></Label>

--- a/src/picker.common.ts
+++ b/src/picker.common.ts
@@ -96,7 +96,7 @@ export class PickerField extends TextField implements TemplatedItemsView {
 
         this.applyCssScope(this._page.actionBar);
 
-        const isNavigationButton = this.androidCloseButtonPosition === "navigationButton";
+        const isNavigationButton = this._page.android && this.androidCloseButtonPosition === "navigationButton";
         const closeButton = isNavigationButton ? new NavigationButton() : new ActionItem();
 
         closeButton.text = "Close";

--- a/src/picker.common.ts
+++ b/src/picker.common.ts
@@ -11,7 +11,7 @@ import { fromObject } from "tns-core-modules/data/observable";
 import { addWeakEventListener, removeWeakEventListener } from "tns-core-modules/ui/core/weak-event-listener";
 import { ObservableArray, ChangedData } from "tns-core-modules/data/observable-array/observable-array";
 import { GridLayout } from 'tns-core-modules/ui/layouts/grid-layout/grid-layout';
-import { ActionItem } from 'tns-core-modules/ui/action-bar/action-bar';
+import { ActionItem, NavigationButton } from 'tns-core-modules/ui/action-bar/action-bar';
 import { Frame } from 'tns-core-modules/ui/frame/frame';
 
 export interface ItemsSource {
@@ -47,7 +47,7 @@ export class PickerField extends TextField implements TemplatedItemsView {
     public selectedIndex: number;
     public iOSCloseButtonPosition: "left" | "right";
     public iOSCloseButtonIcon: number;
-    public androidCloseButtonPosition: "actionBar" | "actionBarIfRoom" | "popup";
+    public androidCloseButtonPosition: "navigationButton" | "actionBar" | "actionBarIfRoom" | "popup";
     public androidCloseButtonIcon: string;
     private _modalListView: ListView;
     private _modalRoot: Frame;
@@ -96,31 +96,34 @@ export class PickerField extends TextField implements TemplatedItemsView {
 
         this.applyCssScope(this._page.actionBar);
 
-        let actionItem = new ActionItem();
-        actionItem.text = "Close";
-        actionItem.on(Button.tapEvent, (args: ItemEventData) => {
-            this.closeCallback(undefined, undefined);
+        const isNavigationButton = this.androidCloseButtonPosition === "navigationButton";
+        const closeButton = isNavigationButton ? new NavigationButton() : new ActionItem();
+
+        closeButton.text = "Close";
+        closeButton.on(Button.tapEvent, () => {
+            this.closeCallback();
         });
+        this.applyCssScope(<any>closeButton);
 
-        this.applyCssScope(<any>actionItem);
-
-        if (actionItem.ios) {
-            actionItem.ios.position = this.iOSCloseButtonPosition;
-            actionItem.ios.systemIcon = this.iOSCloseButtonIcon;
+        if (closeButton.ios) {
+            closeButton.ios.position = this.iOSCloseButtonPosition;
+            closeButton.ios.systemIcon = this.iOSCloseButtonIcon;
+        }
+        if (closeButton.android) {
+            closeButton.android.systemIcon = this.androidCloseButtonIcon;
+            closeButton.android.position = <any>this.androidCloseButtonPosition;
         }
 
-        if (actionItem.android) {
-            actionItem.android.systemIcon = this.androidCloseButtonIcon;
-            actionItem.android.position = this.androidCloseButtonPosition;
+        if (isNavigationButton) {
+            this._page.actionBar.navigationButton = closeButton;
+        } else {
+            this._page.actionBar.actionItems.addItem(closeButton);
         }
-
-        this._page.actionBar.actionItems.addItem(actionItem);
 
         this._modalRoot.on(Page.shownModallyEvent, this.shownModallyHandler.bind(this));
 
         this._modalListView.on(ListView.itemLoadingEvent, this.listViewItemLoadingHandler.bind(this));
         this._modalListView.on(ListView.itemTapEvent, this.listViewItemTapHandler.bind(this));
-        this.applyCssScope(this._modalListView);
         this._modalListView.items = this.items;
 
         this.applyCssScope(this._modalGridLayout);

--- a/src/picker.common.ts
+++ b/src/picker.common.ts
@@ -13,6 +13,7 @@ import { ObservableArray, ChangedData } from "tns-core-modules/data/observable-a
 import { GridLayout } from 'tns-core-modules/ui/layouts/grid-layout/grid-layout';
 import { ActionItem, NavigationButton } from 'tns-core-modules/ui/action-bar/action-bar';
 import { Frame } from 'tns-core-modules/ui/frame/frame';
+import { isAndroid } from 'tns-core-modules/platform';
 
 export interface ItemsSource {
     length: number;
@@ -96,7 +97,7 @@ export class PickerField extends TextField implements TemplatedItemsView {
 
         this.applyCssScope(this._page.actionBar);
 
-        const isNavigationButton = this._page.android && this.androidCloseButtonPosition === "navigationButton";
+        const isNavigationButton = isAndroid && this.androidCloseButtonPosition === "navigationButton";
         const closeButton = isNavigationButton ? new NavigationButton() : new ActionItem();
 
         closeButton.text = "Close";

--- a/src/picker.d.ts
+++ b/src/picker.d.ts
@@ -77,7 +77,7 @@ export class PickerField extends TextField implements TemplatedItemsView {
     /**
      * Gets or sets the position of the 'close' button of the ActionBar of the modal view.
      */
-    public androidCloseButtonPosition: "actionBar" | "actionBarIfRoom" | "popup";
+    public androidCloseButtonPosition: "navigationButton" | "actionBar" | "actionBarIfRoom" | "popup";
 
     /**
      * Gets or sets the icon of the 'close' button of the ActionBar of the modal view.


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
Close button in Android can't be set on the left

## What is the new behavior?
`androidCloseButtonPosition="navigationButton"` creates a NavigationButton on the left.

Fixes/Implements/Closes #14.