### PR TITLE
Resolve missing "className" property of Angular component

### DIFF
--- a/demo-angular/src/app/examples/reactive-forms/reactive-forms-example.component.css
+++ b/demo-angular/src/app/examples/reactive-forms/reactive-forms-example.component.css
@@ -39,6 +39,10 @@ PickerPage ActionBar {
     color: white;
 }
 
+.label-bold {
+    font-weight: bold;
+}
+
 .field-name-label {
     font-size: 20;
     font-weight: bold;
@@ -52,6 +56,12 @@ PickerPage ActionBar {
     margin: 20;
 }
 
-.green-label {
+.invalid-label {
+    color: red;
+    font-size: 20;
+}
+
+.valid-label {
     color: green;
+    font-size: 20;
 }

--- a/demo-angular/src/app/examples/reactive-forms/reactive-forms-example.component.html
+++ b/demo-angular/src/app/examples/reactive-forms/reactive-forms-example.component.html
@@ -14,9 +14,12 @@
         </ng-template>
     </PickerField>
 
-    <GridLayout row="1" col="0" colSpan="2" rows="auto, auto, auto" backgroundColor="white">
+    <StackLayout row="1" col="0" colSpan="2" backgroundColor="white">
         <Button class="submit-button" text="Submit form" (tap)="onSubmit()"></Button>
-        <Label class="centered-label" row="1" text="Picker css classes:"></Label>
-        <Label class="centered-label green-label" row="2" [text]="pickerClassName"></Label>
-    </GridLayout>
+        <Label class="centered-label label-bold" text="Picker.className:"></Label>
+        <Label class="centered-label" [text]="picker.className"></Label>
+        <Label class="centered-label label-bold" text="Picker.nativeElement.className:"></Label>
+        <Label class="centered-label" [text]="picker.nativeElement.className"></Label>
+        <Label [class]="picker.className.includes('ng-invalid') ? 'centered-label invalid-label' : 'centered-label valid-label'" text="Form status !!!"></Label>
+    </StackLayout>
 </GridLayout>>

--- a/demo-angular/src/app/examples/reactive-forms/reactive-forms-example.component.ts
+++ b/demo-angular/src/app/examples/reactive-forms/reactive-forms-example.component.ts
@@ -1,9 +1,10 @@
-import { Component, OnInit, ViewChild } from "@angular/core";
+import { Component, AfterViewInit, ViewChild } from "@angular/core";
 import { FormBuilder, FormGroup, FormControl, Validators } from "@angular/forms";
 import { RouterExtensions } from "nativescript-angular/router";
 import { ObservableArray } from "tns-core-modules/data/observable-array/observable-array";
 import { PickerFieldComponent } from "nativescript-picker/angular";
 import { EventData } from "tns-core-modules/ui/core/view/view";
+import { View } from "tns-core-modules/ui/core/view";
 
 @Component({
     selector: "ns-reactive-forms-example",
@@ -11,7 +12,7 @@ import { EventData } from "tns-core-modules/ui/core/view/view";
     styleUrls: ["reactive-forms-example.component.css"],
     templateUrl: "./reactive-forms-example.component.html"
 })
-export class ReactiveFormsExampleComponent implements OnInit {
+export class ReactiveFormsExampleComponent {
     public pickerItems: ObservableArray<Movie>;
     @ViewChild("picker", { static: false }) pickerComp: PickerFieldComponent;
 
@@ -33,13 +34,7 @@ export class ReactiveFormsExampleComponent implements OnInit {
         });
     }
 
-    ngOnInit(): void {
-        this.pickerClassName = (<any>this.pickerComp.nativeElement).className;
-    }
-
     public movieForm: FormGroup;
-
-    public pickerClassName: string;
 
     public goBack() {
         this.routerExtensions.backToPreviousPage();
@@ -58,15 +53,11 @@ export class ReactiveFormsExampleComponent implements OnInit {
     }
 
     public pickerOpened(args: EventData) {
-        this.pickerClassName = (<any>args.object).className;
-
-        console.log("Picker > Opened; class:", this.pickerClassName);
+        console.log("Picker > Opened; class:", (<View>args.object).className);
     }
 
     public pickerClosed(args: EventData) {
-        this.pickerClassName = (<any>args.object).className;
-
-        console.log("Picker > Closed; class:", this.pickerClassName);
+        console.log("Picker > Closed; class:", (<View>args.object).className);
     }
 }
 

--- a/src/angular/nativescript-picker.directives.ts
+++ b/src/angular/nativescript-picker.directives.ts
@@ -1,7 +1,8 @@
-import { ChangeDetectionStrategy, Component, ElementRef, forwardRef, IterableDiffers } from "@angular/core";
+import { ChangeDetectionStrategy, Component, ElementRef, forwardRef, IterableDiffers, AfterContentInit, OnDestroy } from "@angular/core";
 import { TemplatedItemsComponent, TEMPLATED_ITEMS_COMPONENT } from "nativescript-angular/directives/templated-items-comp";
 import { PickerField } from "../picker";
 import { PickerValueAccessor } from "./nativescript-picker.accessors";
+import { View } from "tns-core-modules/ui/core/view";
 
 @Component({
     selector: "PickerField",
@@ -12,9 +13,15 @@ import { PickerValueAccessor } from "./nativescript-picker.accessors";
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [{ provide: TEMPLATED_ITEMS_COMPONENT, useExisting: forwardRef(() => PickerFieldComponent) }]
 })
-export class PickerFieldComponent extends TemplatedItemsComponent {
+export class PickerFieldComponent extends TemplatedItemsComponent implements AfterContentInit {
+    private _className: string;
+
     public get nativeElement(): PickerField {
         return this.templatedItemsView;
+    }
+
+    public get className(): string {
+        return this._className;
     }
 
     protected templatedItemsView: PickerField;
@@ -22,6 +29,23 @@ export class PickerFieldComponent extends TemplatedItemsComponent {
     constructor(_elementRef: ElementRef,
         _iterableDiffers: IterableDiffers) {
         super(_elementRef, _iterableDiffers);
+    }
+
+    ngAfterContentInit() {
+        super.ngAfterContentInit();
+        this.nativeElement.on("classNameChange", this.onClassNameChange.bind(this));
+    }
+
+    ngOnDestroy() {
+        if (this.nativeElement) {
+            this.nativeElement.off("classNameChange", this.onClassNameChange.bind(this));
+        }
+
+        super.ngOnDestroy();
+    }
+
+    private onClassNameChange(args) {
+        this. _className = (<View>args.object).className;
     }
 }
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
The `className` of the Angular PickerField component returns null.

## What is the new behavior?
The `className` of the Angular PickerField component returns the valid class set.

Fixes/Implements/Closes #[Issue Number].
#27 
